### PR TITLE
Fix Bitvise COM object name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ runs:
             .\BvSshServer-Inst.exe -acceptEULA -defaultInstance
 
           printf "# Setting up the SSH server to allow access..."
-            $cfg = new-object -com "BssCfg815.BssCfg815"
+            $cfg = new-object -com "Bitvise.Bsscfg"
             $cfg.settings.SetDefaults()
             $cfg.settings.access.SetDefaults()
             $cfg.settings.access.winGroups.Clear()


### PR DESCRIPTION
Looks like this changed with Bitvise 9.xx: https://www.bitvise.com/ssh-server-guide-scriptable#changes

Prevents errors like the following:
```
New-Object: D:\a\_temp\bb102f2b-1b0e-40db-8727-017f00ad784b.ps1:37
Line |
  37 |      $cfg = new-object -com "BssCfg815.BssCfg815"
     |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Retrieving the COM class factory for component with CLSID {00000000-0000-0000-0000-000000000000}
     | failed due to the following error: 80040154 Class not registered (0x80040154 (REGDB_E_CLASSNOTREG)).
```