### PR TITLE
Use ngrok v3 agents

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
         if('${{ runner.os }}' -eq 'Linux')
         {
           printf "# Preparing environment..."
-            echo "ngrok-stable-linux-386.zip" > ngrok_zip_name
+            echo "ngrok-v3-stable-linux-amd64.zip" > ngrok_zip_name
             whoami > ssh_user
           printf " [DONE]\n\n"
           
@@ -49,7 +49,7 @@ runs:
         elseif('${{ runner.os }}' -eq 'macOS')
         {
           printf "# Preparing environment..."
-            echo "ngrok-stable-darwin-amd64.zip" > ngrok_zip_name
+            echo "ngrok-v3-stable-darwin-amd64.zip" > ngrok_zip_name
             echo "root" > ssh_user
           printf " [DONE]\n\n"
   
@@ -62,7 +62,7 @@ runs:
         elseif('${{ runner.os }}' -eq 'Windows')
         {
           printf "# Preparing environment..."
-            echo "ngrok-stable-windows-amd64.zip" > ngrok_zip_name
+            echo "ngrok-v3-stable-windows-amd64.zip" > ngrok_zip_name
             echo $env:UserName > ssh_user
           printf " [DONE]\n\n"
           
@@ -95,7 +95,7 @@ runs:
     - name: Install and setup ngrok
       run: |
         echo "# Install ngrok"
-          curl https://bin.equinox.io/c/4VmDzA7iaHb/$(cat ngrok_zip_name) --output ngrok.zip
+          curl https://bin.equinox.io/c/bNyj1mQVY4c/$(cat ngrok_zip_name) --output ngrok.zip
           unzip ngrok.zip
           chmod +x ./ngrok
 


### PR DESCRIPTION
I have received a notification from ngrok:

> We’re dropping you this end-of-year note because we’ve seen you connect to ngrok in the past 90 days with a soon-to-be-deprecated agent. We need to inform you that all ngrok agents version 3.1 and older will stop working on January 15th, 2024 for all free users. 

This PR updates the download URLs to use the latest v3 agents.

I am always a bit sceptical when I see cryptic download URLs. In this case, you can cross-check the URL against the official ngrok documentation at the time of writing: https://github.com/ngrok/ngrok-docs/blob/1b7f012c469982a4ef389d1a85b63e6b21d904f5/docs/guides/device-gateway/linux.md